### PR TITLE
CORE-8375 Rename `app_count` to `total` in app listings.

### DIFF
--- a/src/mescal/agave_de_v2.clj
+++ b/src/mescal/agave_de_v2.clj
@@ -36,8 +36,8 @@
 (defn search-apps
   [agave jobs-enabled? search-term]
   (let [matching-apps (find-matching-apps agave jobs-enabled? search-term)]
-    {:app_count (count matching-apps)
-     :apps      matching-apps}))
+    {:total (count matching-apps)
+     :apps  matching-apps}))
 
 (defn get-app
   [agave app-id]

--- a/src/mescal/agave_de_v2/app_listings.clj
+++ b/src/mescal/agave_de_v2/app_listings.clj
@@ -7,7 +7,7 @@
   {:id           c/hpc-group-id
    :is_public    true
    :name         c/hpc-group-name
-   :app_count    -1})
+   :total        -1})
 
 (defn get-app-name
   [app]
@@ -42,8 +42,8 @@
 (defn- format-app-listing-response
   [listing statuses jobs-enabled?]
   (assoc (hpc-app-group)
-    :apps      (map (partial format-app-listing statuses jobs-enabled?) listing)
-    :app_count (count listing)))
+    :apps  (map (partial format-app-listing statuses jobs-enabled?) listing)
+    :total (count listing)))
 
 (defn list-apps
   ([agave statuses jobs-enabled?]


### PR DESCRIPTION
This PR renames the `app_count` field to `total` in Agave client app listing responses.