### PR TITLE
CORE-8555: Allow sharing of Agave apps

### DIFF
--- a/src/mescal/agave_de_v2.clj
+++ b/src/mescal/agave_de_v2.clj
@@ -81,6 +81,10 @@
       ;; app is public
       (= required-level "read"))))
 
+(defn share-app-with-user
+  [agave username app-id level]
+  (.shareAppWithUser agave app-id username (apps/format-update-permission level)))
+
 (defn prepare-job-submission
   [agave submission]
   (jobs/prepare-submission agave (.getApp agave (:app_id submission)) submission))

--- a/src/mescal/agave_de_v2.clj
+++ b/src/mescal/agave_de_v2.clj
@@ -59,6 +59,10 @@
   [agave app-id]
   (mapv :id (:inputs (.getApp agave app-id))))
 
+(defn list-app-permissions
+  [agave app-ids]
+  (map #(apps/format-app-permissions % (.listAppPermissions agave %)) app-ids))
+
 (defn prepare-job-submission
   [agave submission]
   (jobs/prepare-submission agave (.getApp agave (:app_id submission)) submission))

--- a/src/mescal/agave_de_v2/apps.clj
+++ b/src/mescal/agave_de_v2/apps.clj
@@ -212,6 +212,15 @@
                                  :else ""))))
 
 (defn format-app-permissions
+  "Formats an Agave app permissions response for use in the DE."
   [app-id permissions]
   {:id app-id
    :permissions (map format-app-permission permissions)})
+
+(defn format-update-permission
+  "Formats a DE permission level for updating in Agave."
+  [level]
+  (when level
+    (if (= level "read")
+      "read_execute"
+      "all")))

--- a/src/mescal/agave_de_v2/apps.clj
+++ b/src/mescal/agave_de_v2/apps.clj
@@ -1,8 +1,7 @@
 (ns mescal.agave-de-v2.apps
   (:use [medley.core :only [remove-vals]]
         [mescal.agave-de-v2.app-listings :only [get-app-name]])
-  (:require [clojure.string :as string]
-            [mescal.agave-de-v2.constants :as c]
+  (:require [mescal.agave-de-v2.constants :as c]
             [mescal.agave-de-v2.params :as mp]
             [mescal.util :as util]))
 
@@ -202,3 +201,17 @@
 (defn format-app-rerun-info
   [agave app job]
   (format-app agave app (partial format-groups-for-rerun agave job)))
+
+(defn- format-app-permission
+  [permission-map]
+  (-> permission-map
+      (select-keys [:username :permission])
+      (clojure.set/rename-keys {:username :user})
+      (update :permission #(cond (:write %) "own"
+                                 (:read %) "read"
+                                 :else ""))))
+
+(defn format-app-permissions
+  [app-id permissions]
+  {:id app-id
+   :permissions (map format-app-permission permissions)})

--- a/src/mescal/agave_v2.clj
+++ b/src/mescal/agave_v2.clj
@@ -110,6 +110,10 @@
   [base-url token-info-fn timeout app-id username]
   (agave-get token-info-fn timeout (curl/url base-url "/apps/v2" app-id "pems" username)))
 
+(defn share-app-with-user
+  [base-url token-info-fn timeout app-id username level]
+  (agave-post token-info-fn timeout (curl/url base-url "/apps/v2" app-id "pems" username) {:permission level}))
+
 (defn submit-job
   [base-url token-info-fn timeout submission]
   (agave-post token-info-fn timeout (curl/url base-url "/jobs/v2/") submission))

--- a/src/mescal/agave_v2.clj
+++ b/src/mescal/agave_v2.clj
@@ -106,6 +106,10 @@
   [base-url token-info-fn timeout app-id]
   (agave-get token-info-fn timeout (curl/url base-url "/apps/v2" app-id "pems")))
 
+(defn get-app-permission
+  [base-url token-info-fn timeout app-id username]
+  (agave-get token-info-fn timeout (curl/url base-url "/apps/v2" app-id "pems" username)))
+
 (defn submit-job
   [base-url token-info-fn timeout submission]
   (agave-post token-info-fn timeout (curl/url base-url "/jobs/v2/") submission))

--- a/src/mescal/agave_v2.clj
+++ b/src/mescal/agave_v2.clj
@@ -102,6 +102,10 @@
   [base-url token-info-fn timeout app-id]
   (agave-get token-info-fn timeout (curl/url base-url "/apps/v2" app-id)))
 
+(defn list-app-permissions
+  [base-url token-info-fn timeout app-id]
+  (agave-get token-info-fn timeout (curl/url base-url "/apps/v2" app-id "pems")))
+
 (defn submit-job
   [base-url token-info-fn timeout submission]
   (agave-post token-info-fn timeout (curl/url base-url "/jobs/v2/") submission))

--- a/src/mescal/core.clj
+++ b/src/mescal/core.clj
@@ -11,6 +11,7 @@
   (getApp [_ app-id])
   (getAppPermission [_ app-id username])
   (listAppPermissions [_ app-ids])
+  (shareAppWithUser [_ app-id username level])
   (submitJob [_ submission])
   (listJobs [_] [_ job-ids])
   (listJob [_ job-id])
@@ -52,6 +53,9 @@
   (listAppPermissions [_ app-id]
     (v2/check-access-token token-info-fn timeout)
     (v2/list-app-permissions base-url token-info-fn timeout app-id))
+  (shareAppWithUser [_ app-id username level]
+    (v2/check-access-token token-info-fn timeout)
+    (v2/share-app-with-user base-url token-info-fn timeout app-id username level))
   (submitJob [_ submission]
     (v2/check-access-token token-info-fn timeout)
     (v2/submit-job base-url token-info-fn timeout submission))

--- a/src/mescal/core.clj
+++ b/src/mescal/core.clj
@@ -9,6 +9,7 @@
   (listApps [_] [_ app-ids])
   (listAppsWithOntology [_ term])
   (getApp [_ app-id])
+  (getAppPermission [_ app-id username])
   (listAppPermissions [_ app-ids])
   (submitJob [_ submission])
   (listJobs [_] [_ job-ids])
@@ -45,6 +46,9 @@
   (getApp [_ app-id]
     (v2/check-access-token token-info-fn timeout)
     (v2/get-app base-url token-info-fn timeout app-id))
+  (getAppPermission [_ app-id username]
+    (v2/check-access-token token-info-fn timeout)
+    (v2/get-app-permission base-url token-info-fn timeout app-id username))
   (listAppPermissions [_ app-id]
     (v2/check-access-token token-info-fn timeout)
     (v2/list-app-permissions base-url token-info-fn timeout app-id))

--- a/src/mescal/core.clj
+++ b/src/mescal/core.clj
@@ -9,6 +9,7 @@
   (listApps [_] [_ app-ids])
   (listAppsWithOntology [_ term])
   (getApp [_ app-id])
+  (listAppPermissions [_ app-ids])
   (submitJob [_ submission])
   (listJobs [_] [_ job-ids])
   (listJob [_ job-id])
@@ -44,6 +45,9 @@
   (getApp [_ app-id]
     (v2/check-access-token token-info-fn timeout)
     (v2/get-app base-url token-info-fn timeout app-id))
+  (listAppPermissions [_ app-id]
+    (v2/check-access-token token-info-fn timeout)
+    (v2/list-app-permissions base-url token-info-fn timeout app-id))
   (submitJob [_ submission]
     (v2/check-access-token token-info-fn timeout)
     (v2/submit-job base-url token-info-fn timeout submission))

--- a/src/mescal/de.clj
+++ b/src/mescal/de.clj
@@ -15,6 +15,7 @@
   (getAppInputIds [_ app-id])
   (hasAppPermission [_ username app-id required-level])
   (listAppPermissions [_ app-ids])
+  (shareAppWithUser [_ username app-id level])
   (submitJob [_ submission])
   (prepareJobSubmission [_ submission])
   (sendJobSubmission [_ submission])
@@ -54,6 +55,8 @@
     (v2/has-app-permission agave username app-id required-level))
   (listAppPermissions [_ app-ids]
     (v2/list-app-permissions agave app-ids))
+  (shareAppWithUser [_ username app-id level]
+    (v2/share-app-with-user agave username app-id level))
   (submitJob [this submission]
     (->> (.prepareJobSubmission this submission)
          (.sendJobSubmission this)))

--- a/src/mescal/de.clj
+++ b/src/mescal/de.clj
@@ -13,6 +13,7 @@
   (listAppTasks [_ app-id])
   (getAppToolListing [_ app-id])
   (getAppInputIds [_ app-id])
+  (listAppPermissions [_ app-ids])
   (submitJob [_ submission])
   (prepareJobSubmission [_ submission])
   (sendJobSubmission [_ submission])
@@ -48,6 +49,8 @@
     (v2/get-app-tool-listing agave app-id))
   (getAppInputIds [_ app-id]
     (v2/get-app-input-ids agave app-id))
+  (listAppPermissions [_ app-ids]
+    (v2/list-app-permissions agave app-ids))
   (submitJob [this submission]
     (->> (.prepareJobSubmission this submission)
          (.sendJobSubmission this)))

--- a/src/mescal/de.clj
+++ b/src/mescal/de.clj
@@ -13,6 +13,7 @@
   (listAppTasks [_ app-id])
   (getAppToolListing [_ app-id])
   (getAppInputIds [_ app-id])
+  (hasAppPermission [_ username app-id required-level])
   (listAppPermissions [_ app-ids])
   (submitJob [_ submission])
   (prepareJobSubmission [_ submission])
@@ -49,6 +50,8 @@
     (v2/get-app-tool-listing agave app-id))
   (getAppInputIds [_ app-id]
     (v2/get-app-input-ids agave app-id))
+  (hasAppPermission [_ username app-id required-level]
+    (v2/has-app-permission agave username app-id required-level))
   (listAppPermissions [_ app-ids]
     (v2/list-app-permissions agave app-ids))
   (submitJob [this submission]


### PR DESCRIPTION
These changes add support for fetching and setting Agave app permissions, as well as converting permission values to/from DE permission values.