### PR TITLE
CORE-8516: default null app descriptions to the empty string

### DIFF
--- a/src/mescal/agave_de_v2/app_listings.clj
+++ b/src/mescal/agave_de_v2/app_listings.clj
@@ -20,7 +20,7 @@
         system   (:executionSystem listing)]
     {:id                   (:id listing)
      :name                 (get-app-name listing)
-     :description          (:shortDescription listing)
+     :description          (or (:shortDescription listing) "")
      :integration_date     mod-time
      :edited_date          mod-time
      :app_type             c/hpc-app-type

--- a/src/mescal/agave_de_v2/apps.clj
+++ b/src/mescal/agave_de_v2/apps.clj
@@ -103,7 +103,7 @@
         :label            app-label
         :id               (:id app)
         :name             app-label
-        :description      (:shortDescription app)
+        :description      (or (:shortDescription app) "")
         :integration_date mod-time
         :edited_date      mod-time
         :app_type         c/hpc-app-type


### PR DESCRIPTION
This change is tiny, so I'm just going to merge it immediately. I wanted to have a record of the change, though.