### PR TITLE
Minor improvements and bug fixes.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.cyverse/mescal "3.0.3-SNAPSHOT"
+(defproject org.cyverse/mescal "3.0.3"
   :description "A Clojure client library for the Agave API."
   :url "https://github.com/cyverse-de/mescal"
   :license {:name "BSD Standard License"

--- a/src/mescal/agave_de_v2/app_listings.clj
+++ b/src/mescal/agave_de_v2/app_listings.clj
@@ -20,7 +20,7 @@
         system   (:executionSystem listing)]
     {:id                   (:id listing)
      :name                 (get-app-name listing)
-     :description          (or (:shortDescription listing) "")
+     :description          (or (:shortDescription listing) "[no description provided]")
      :integration_date     mod-time
      :edited_date          mod-time
      :app_type             c/hpc-app-type
@@ -33,7 +33,7 @@
      :integrator_email     c/unknown-value
      :integrator_name      c/unknown-value
      :is_favorite          false
-     :is_public            (:isPublic listing)
+     :is_public            (boolean (:isPublic listing))
      :pipeline_eligibility {:is_valid true :reason ""}
      :rating               {:average 0.0 :total 0}
      :step_count           1

--- a/src/mescal/agave_de_v2/app_listings.clj
+++ b/src/mescal/agave_de_v2/app_listings.clj
@@ -14,13 +14,17 @@
   [app]
   (str (or (:label app) (:name app)) " " (:version app)))
 
+(defn get-app-description
+  [app]
+  (or (:shortDescription app) "[no description provided]"))
+
 (defn- format-app-listing
   [statuses jobs-enabled? listing]
   (let [mod-time (util/to-utc (:lastModified listing))
         system   (:executionSystem listing)]
     {:id                   (:id listing)
      :name                 (get-app-name listing)
-     :description          (or (:shortDescription listing) "[no description provided]")
+     :description          (get-app-description listing)
      :integration_date     mod-time
      :edited_date          mod-time
      :app_type             c/hpc-app-type

--- a/src/mescal/agave_de_v2/app_listings.clj
+++ b/src/mescal/agave_de_v2/app_listings.clj
@@ -38,7 +38,8 @@
      :rating               {:average 0.0 :total 0}
      :step_count           1
      :permission           "read"
-     :wiki_url             ""}))
+     :wiki_url             ""
+     :owner                (:owner listing)}))
 
 (defn- format-app-listing-response
   [listing statuses jobs-enabled?]

--- a/src/mescal/agave_de_v2/apps.clj
+++ b/src/mescal/agave_de_v2/apps.clj
@@ -1,6 +1,6 @@
 (ns mescal.agave-de-v2.apps
   (:use [medley.core :only [remove-vals]]
-        [mescal.agave-de-v2.app-listings :only [get-app-name]])
+        [mescal.agave-de-v2.app-listings :only [get-app-name get-app-description]])
   (:require [mescal.agave-de-v2.constants :as c]
             [mescal.agave-de-v2.params :as mp]
             [mescal.util :as util]))
@@ -103,7 +103,7 @@
         :label            app-label
         :id               (:id app)
         :name             app-label
-        :description      (or (:shortDescription app) "")
+        :description      (get-app-description app)
         :integration_date mod-time
         :edited_date      mod-time
         :app_type         c/hpc-app-type
@@ -138,7 +138,7 @@
      :id                   (:id app)
      :name                 (get-app-name app)
      :references           []
-     :description          (:shortDescription app)
+     :description          (get-app-description app)
      :deleted              false
      :disabled             (system-available? agave (:executionSystem app))
      :tools                [(format-tool-for-app app)]

--- a/src/mescal/agave_v2.clj
+++ b/src/mescal/agave_v2.clj
@@ -94,9 +94,13 @@
   [base-url token-info-fn timeout system-name]
   (agave-get token-info-fn timeout (curl/url base-url "/systems/v2/" system-name)))
 
+(def ^:private app-listing-fields
+  ["id" "label" "name" "version" "lastModified" "executionSystem" "shortDescription" "isPublic" "owner"])
+
 (defn- app-listing-params
   [params]
   (merge (select-keys params [:page-len :id.in :ontology.like])
+         {:filter (string/join "," app-listing-fields)}
          (case (:app-subset params)
            :public  {:publicOnly "true"}
            :private {:privateOnly "true"}


### PR DESCRIPTION
This PR makes two changes. The first change is to include the `owner` field in app listings, which can be used by the `apps` service to get app integrator information. The second change is to ensure that the `description` field is populated whenever an app is retrieved. This fixes a bug where the description field was nil, causing a schema validation failure.