### PR TITLE
CORE-893: add the archiveOnAppError flag to TAPIS job submissions

### DIFF
--- a/src/mescal/agave_de_v2/jobs.clj
+++ b/src/mescal/agave_de_v2/jobs.clj
@@ -72,12 +72,13 @@
 (defn prepare-submission
   [agave app submission]
   (->> (assoc (prepare-params agave app (:paramPrefix submission) (:config submission))
-              :name           (build-job-name submission)
-              :appId          (:app_id submission)
-              :archive        true
-              :archivePath    (.agaveFilePath agave (:output_dir submission))
-              :archiveSystem  (.storageSystem agave)
-              :notifications  (job-notifications (:callbackUrl submission)))
+              :name              (build-job-name submission)
+              :appId             (:app_id submission)
+              :archive           true
+              :archiveOnAppError true
+              :archivePath       (.agaveFilePath agave (:output_dir submission))
+              :archiveSystem     (.storageSystem agave)
+              :notifications     (job-notifications (:callbackUrl submission)))
        (remove-vals nil?)))
 
 (defn- app-enabled?


### PR DESCRIPTION
This is a tiny change, and I submitted a job to verify that it wouldn't break job submissions. I'm going to merge this one immediately. As usual, reviews are still welcome.