### PR TITLE
CORE-1253: updated the limit check result format

### DIFF
--- a/src/mescal/agave_de_v2/constants.clj
+++ b/src/mescal/agave_de_v2/constants.clj
@@ -12,5 +12,5 @@
    :name hpc-group-name})
 
 (def limit-checks
-  {:canRun      true
-   :reasonCodes []})
+  {:canRun  true
+   :results []})


### PR DESCRIPTION
This is an extremely tiny change to update the empty limit check result to match the new schema.