### PR TITLE
CORE-1541: added logging for outgoing job submissions

### DIFF
--- a/src/mescal/agave_v2.clj
+++ b/src/mescal/agave_v2.clj
@@ -129,6 +129,7 @@
 
 (defn submit-job
   [base-url token-info-fn timeout submission]
+  (util/log-json "job" submission)
   (agave-post token-info-fn timeout (curl/url base-url "/jobs/v2/") submission))
 
 (defn list-jobs

--- a/src/mescal/util.clj
+++ b/src/mescal/util.clj
@@ -29,6 +29,13 @@
     (cheshire/decode source true)
     (cheshire/decode-stream (reader source) true)))
 
+(defn log-json
+  [description m]
+  (->> (cheshire/encode m {:pretty true})
+       (str description ": ")
+       (log/info))
+  m)
+
 (def ^:private accepted-timestamp-formats
   ["yyyy-MM-dd'T'HH:mm:ssZZ"
    "yyyy-MM-dd'T'HH:mm:ss.SSSZZ"])


### PR DESCRIPTION
This is just a tiny change to add logging for outgoing TAPIS job submissions.