### PR TITLE
CORE-1812 Add new fields to app details responses

### DIFF
--- a/src/mescal/agave_de_v2/apps.clj
+++ b/src/mescal/agave_de_v2/apps.clj
@@ -145,6 +145,15 @@
      :disabled             (system-disabled? agave (:executionSystem app))
      :tools                [(format-tool-for-app app)]
      :categories           [c/hpc-group-overview]
+     :app_type             c/hpc-app-type
+     :can_favor            false
+     :can_rate             false
+     :can_run              true
+     :is_public            (boolean (:isPublic app))
+     :permission           "read"
+     :pipeline_eligibility {:is_valid true :reason ""}
+     :rating               {:average 0.0 :total 0}
+     :step_count           1
      :suggested_categories []
      :system_id            c/hpc-system-id
      :wiki_url             (:helpURI app)


### PR DESCRIPTION
This PR will add new fields to app details responses, since it now returns all the same fields as the listing endpoint (see CORE-1517 and cyverse-de/apps#249).